### PR TITLE
LSP Scala setup, take 2

### DIFF
--- a/init.el
+++ b/init.el
@@ -1261,9 +1261,15 @@ _t_: toggle    _._: toggle hydra _H_: help       C-o other win no-select
   :config (global-flycheck-mode 1))
 
 (use-package lsp-mode                   ; Language Server Protocol support for Emacs
-  :hook (scala-mode . lsp-mode)
+  :commands lsp
+  :hook (prog-mode . lsp-mode)
   :init
-  (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references))
+  ;; Prefer `lsp-ui' over flymake for errors
+  (setq lsp-prefer-flymake nil)
+
+  ;; Evil binding for `lsp-find-references'
+  (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references)
+  :config (require 'lsp-clients))
 
 (use-package lsp-ui                     ; UI support for `lsp-mode'
   :hook (lsp-mode . lsp-ui-mode))

--- a/init.el
+++ b/init.el
@@ -1290,68 +1290,76 @@ _t_: toggle    _._: toggle hydra _H_: help       C-o other win no-select
               ("C-c m e e" . eval-last-sexp)
               ("C-c m e f" . eval-defun)))
 
-;;; Scala support
+;; Scala support
 
-(use-package scala-mode                 ; Major mode for editing Scala files
+(use-package scala-mode                 ; Major mode for Scala
   :defer t
   :config
   ;; Indentation preferences
   (setq scala-indent:default-run-on-strategy
         scala-indent:operator-strategy)
 
-  ;; For correct newline behavior in multiline comments
+  ;; Insert newline in a multiline comment should insert an asterisk
   (defun ad|scala-mode-newline-comments ()
-    "Insert a leading asterisk in multiline comments, when hitting RET."
+    "Insert a leading asterisk in multiline comments, when hitting 'RET'."
     (interactive)
     (newline-and-indent)
     (scala-indent:insert-asterisk-on-multiline-comment))
+  (define-key scala-mode-map (kbd "RET") #'ad|scala-mode-newline-comments))
 
-  (define-key scala-mode-map (kbd "RET")
-    #'ad|scala-mode-newline-comments))
-
-(use-package sbt-mode                   ; Interactive support for Satan's Build Tool
-  :commands (sbt-start sbt-command)
+(use-package sbt-mode                   ; Support for Satan's Build Tool
+  :commands sbt-start sbt-command
   :config
   ;; Don't pop up SBT buffers automatically
   (setq sbt:display-command-buffer nil)
 
-  ;; WORKAROUND: https://github.com/ensime/emacs-sbt-mode/issues/31 allows using
-  ;; SPACE when in the minibuffer
+  ;; WORKAROUND: https://github.com/ensime/emacs-sbt-mode/issues/31
+  ;; allows using SPACE when in the minibuffer
   (substitute-key-definition
    'minibuffer-complete-word
    'self-insert-command
    minibuffer-local-completion-map))
 
-(use-package flycheck                   ; On the fly syntax checking for Emacs
+(use-package lsp-scala                  ; LSP backend for Scala, using Metals
+  :after (scala-mode lsp-mode)
+  :load-path "site-lisp/lsp-scala"
+  :demand t
+  :hook (scala-mode . lsp)
+  :init (setq lsp-scala-server-command (executable-find "metals-emacs")))
+
+;; TODO: move to general programming
+
+(use-package flycheck
   :hook (prog-mode . flycheck-mode))
 
 (use-package lsp-mode
-  :commands lsp
-  :hook (prog-mode . lsp-mode)
-  :init
-  (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references)
-  :config (require 'lsp-clients))
+ :commands lsp
+ :hook (prog-mode . lsp-mode)
+ :init
+ ;; Prefer `lsp-ui' over `flymake' for errors
+ (setq lsp-prefer-flymake nil)
+ ;; Evil keybinding for `lsp-find-references'
+ (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references)
+ :config (require 'lsp-clients))
 
 (use-package lsp-ui
   :hook (lsp-mode . lsp-ui-mode))
 
-(use-package company-lsp
-  :after (company lsp-mode)
-  :config (add-to-list 'company-backends 'company-lsp)
-  :custom
-  (company-lsp-async t)
-  (company-lsp-enable-snippet t))
+;; (use-package lsp-mode
+;;   :commands lsp
+;;   :hook (prog-mode . lsp-mode)
+;;   :init
+;;   (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references)
+;;   :config (require 'lsp-clients))
 
-(use-package lsp-scala                  ; LSP backend for Scala, using Metals
-  :load-path "site-lisp/lsp-scala"
-  :after (scala-mode lsp-mode)
-  :init
-  ;; Where to find the metals executable
-  (setq lsp-scala-server-command (executable-find "metals-emacs"))
+;; (use-package company-lsp
+;;   :after (company lsp-mode)
+;;   :config (add-to-list 'company-backends 'company-lsp)
+;;   :custom
+;;   (company-lsp-async t)
+;;   (company-lsp-enable-snippet t))
 
-  (add-hook 'scala-mode-hook #'lsp))
-
-;;; Python support
+;; Python support
 
 (use-package elpy                       ; Emacs Lisp Python environment
   :defer 4

--- a/init.el
+++ b/init.el
@@ -1322,30 +1322,34 @@ _t_: toggle    _._: toggle hydra _H_: help       C-o other win no-select
    'self-insert-command
    minibuffer-local-completion-map))
 
-(use-package flycheck
-  :config (global-flycheck-mode 1))
+(use-package flycheck                   ; On the fly syntax checking for Emacs
+  :hook (prog-mode . flycheck-mode))
 
 (use-package lsp-mode
-  :hook (scala-mode . lsp-mode)
+  :commands lsp
+  :hook (prog-mode . lsp-mode)
   :init
-  (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references))
+  (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references)
+  :config (require 'lsp-clients))
 
 (use-package lsp-ui
   :hook (lsp-mode . lsp-ui-mode))
 
-;; (use-package company-lsp
-;;   :after (company lsp-mode)
-;;   :config (add-to-list 'company-backends 'company-lsp)
-;;   :custom
-;;   (company-lsp-async t)
-;;   (company-lsp-enable-snippet t))
+(use-package company-lsp
+  :after (company lsp-mode)
+  :config (add-to-list 'company-backends 'company-lsp)
+  :custom
+  (company-lsp-async t)
+  (company-lsp-enable-snippet t))
 
-(use-package lsp-scala
+(use-package lsp-scala                  ; LSP backend for Scala, using Metals
   :load-path "site-lisp/lsp-scala"
   :after (scala-mode lsp-mode)
-  :demand t
-  :hook (scala-mode . lsp)
-  :init (setq lsp-scala-server-command (executable-find "metals-emacs")))
+  :init
+  ;; Where to find the metals executable
+  (setq lsp-scala-server-command (executable-find "metals-emacs"))
+
+  (add-hook 'scala-mode-hook #'lsp))
 
 ;;; Python support
 

--- a/init.el
+++ b/init.el
@@ -1257,7 +1257,25 @@ _t_: toggle    _._: toggle hydra _H_: help       C-o other win no-select
   :after company
   :config (company-quickhelp-mode 1))
 
-;;; Markdown support
+(use-package flycheck                   ; On the fly syntax checking for Emacs
+  :config (global-flycheck-mode 1))
+
+(use-package lsp-mode                   ; Language Server Protocol support for Emacs
+  :hook (scala-mode . lsp-mode)
+  :init
+  (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references))
+
+(use-package lsp-ui                     ; UI support for `lsp-mode'
+  :hook (lsp-mode . lsp-ui-mode))
+
+;; (use-package company-lsp
+;;   :after (company lsp-mode)
+;;   :config (add-to-list 'company-backends 'company-lsp)
+;;   :custom
+;;   (company-lsp-async t)
+;;   (company-lsp-enable-snippet t))
+
+;; Markdown support
 
 (use-package markdown-mode              ; Major mode for editing Markdown/GFM files
   :commands (markdown-mode gfm-mode)
@@ -1320,44 +1338,12 @@ _t_: toggle    _._: toggle hydra _H_: help       C-o other win no-select
    'self-insert-command
    minibuffer-local-completion-map))
 
-(use-package lsp-scala                  ; LSP backend for Scala, using Metals
-  :after (scala-mode lsp-mode)
+(use-package lsp-scala                  ; LSP support for Scala, using Metals
   :load-path "site-lisp/lsp-scala"
+  :after (scala-mode lsp-mode)
   :demand t
   :hook (scala-mode . lsp)
   :init (setq lsp-scala-server-command (executable-find "metals-emacs")))
-
-;; TODO: move to general programming
-
-(use-package flycheck
-  :hook (prog-mode . flycheck-mode))
-
-(use-package lsp-mode
- :commands lsp
- :hook (prog-mode . lsp-mode)
- :init
- ;; Prefer `lsp-ui' over `flymake' for errors
- (setq lsp-prefer-flymake nil)
- ;; Evil keybinding for `lsp-find-references'
- (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references)
- :config (require 'lsp-clients))
-
-(use-package lsp-ui
-  :hook (lsp-mode . lsp-ui-mode))
-
-;; (use-package lsp-mode
-;;   :commands lsp
-;;   :hook (prog-mode . lsp-mode)
-;;   :init
-;;   (evil-define-key '(normal visual) lsp-mode-map "gr" 'lsp-find-references)
-;;   :config (require 'lsp-clients))
-
-;; (use-package company-lsp
-;;   :after (company lsp-mode)
-;;   :config (add-to-list 'company-backends 'company-lsp)
-;;   :custom
-;;   (company-lsp-async t)
-;;   (company-lsp-enable-snippet t))
 
 ;; Python support
 


### PR DESCRIPTION
This PR resets the Scala/Metals setup to something very close to the documentation on the Metals site. I think that: `(setq lsp-prefer-flymake nil)` is a really important setting, because I didn't have it on before, and I was getting a lot of false red squigglies that didn't go away even on succcessful compilation.