### PR TITLE
Disable ivy-posframe

### DIFF
--- a/init.el
+++ b/init.el
@@ -941,28 +941,6 @@ Redefined to allow pop-up windows."
          ivy-rich-switch-buffer-align-virtual-buffer t)
   :config (ivy-rich-mode 1))
 
-(use-package ivy-posframe
-  :demand t
-  :init
-  ;; Set posframe width in columns
-  (gsetq ivy-posframe-width 120)
-
-  ;; Add fringe because borders don't work on OSX
-  ;; See:https://github.com/tumashu/posframe/issues/30#issuecomment-495928777
-  (gsetq ivy-posframe-parameters
-         '((left-fringe . 8)
-           (right-fringe . 8)))
-
-  ;; Display settings
-  (gsetq ivy-posframe-display-functions-alist
-         '((swiper                            . nil)                           ; nothing for swiper, it gets in the way
-           (complete-symbol                   . ivy-posframe-display-at-point) ; completion at point
-           (counsel-M-x                       . ivy-posframe-display-at-frame-center) ; counsel in the middle
-           (counsel-projectile-switch-project . ivy-posframe-display-at-frame-center) ; switch project too
-           (t                                 . ivy-posframe-display)))
-
-  :config (ivy-posframe-mode))
-
 (use-package yasnippet
   :defer 3
   :general
@@ -1076,9 +1054,6 @@ Redefined to allow pop-up windows."
   :demand t
   :config
   (company-prescient-mode))
-
-(use-package company-posframe
-  :config (company-posframe-mode 1))
 
 (use-package flycheck
   :ghook ('after-init-hook #'global-flycheck-mode)


### PR DESCRIPTION
I really wanted this to work, but it just doesn't. There are two main issues:

1. Posframe borders do not work with GNU Emacs on OSX (this works for the macport version)
2. This does not play nicely with `ivy-avy` which I am using regularly

I looked into both of these issues, and the former unfortunately doesn't seem to have a solution, other than using the macports version of Emacs, which I'm not doing. The second issue seems like it can be fixed, or could be, with enough work (see: https://github.com/tumashu/ivy-posframe/issues/6) but I'm not up for doing it now.

Not having a visual border around the posframe is kind of a deal-breaker for me, as it otherwise blends into the existing background, and is more confusing than helpful. I tried the trick with adding fringe to `ivy-posframe-parameters` but that didn't work for me either. Sigh.